### PR TITLE
Add adapter

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -1,0 +1,10 @@
+import * as viem from "viem";
+
+export interface Adapter {
+    getOracleId(): string;
+    fetchOffchainData(
+        client: viem.Client,
+        oracleContract: viem.Address,
+        oracleQuery: viem.Hex,
+    ): Promise<viem.Hex>;
+}

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -1,10 +1,10 @@
 import * as viem from "viem";
 
 export interface Adapter {
-    getOracleId(): string;
-    fetchOffchainData(
-        client: viem.Client,
-        oracleContract: viem.Address,
-        oracleQuery: viem.Hex,
-    ): Promise<viem.Hex>;
+  getOracleId(): string;
+  fetchOffchainData(
+    client: viem.Client,
+    oracleContract: viem.Address,
+    oracleQuery: viem.Hex
+  ): Promise<viem.Hex>;
 }

--- a/src/adapters/default.ts
+++ b/src/adapters/default.ts
@@ -3,37 +3,33 @@ import * as viem from "viem";
 import fetch from "node-fetch";
 
 export class DefaultAdapter implements Adapter {
-    constructor(
-        private oracleId: string,
-        private url: string,
-    ) {
-    }
+  constructor(private oracleId: string, private url: string) {}
 
-    getOracleId(): string {
-        return this.oracleId;
-    }
+  getOracleId(): string {
+    return this.oracleId;
+  }
 
-    async fetchOffchainData(
-        _client: viem.Client,
-        _oracleContract: viem.Address,
-        oracleQuery: viem.Hex,
-    ): Promise<viem.Hex> {
-        return this.fetch(oracleQuery);
-    }
+  async fetchOffchainData(
+    _client: viem.Client,
+    _oracleContract: viem.Address,
+    oracleQuery: viem.Hex
+  ): Promise<viem.Hex> {
+    return this.fetch(oracleQuery);
+  }
 
-    private async fetch(data: viem.Hex): Promise<viem.Hex> {
-      const response = await fetch(this.url, {
-        method: "POST",
-        headers: {
-          "Content-Type": "text/plain",
-        },
-        body: data,
-      });
-      if (response.status !== 200) {
-        throw new Error(
-          `error fetching data (${response.status}): ${await response.text()}`
-        );
-      }
-      return (await response.text()) as viem.Hex;
+  private async fetch(data: viem.Hex): Promise<viem.Hex> {
+    const response = await fetch(this.url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "text/plain",
+      },
+      body: data,
+    });
+    if (response.status !== 200) {
+      throw new Error(
+        `error fetching data (${response.status}): ${await response.text()}`
+      );
     }
+    return (await response.text()) as viem.Hex;
+  }
 }

--- a/src/adapters/default.ts
+++ b/src/adapters/default.ts
@@ -1,0 +1,39 @@
+import { Adapter } from "../adapter";
+import * as viem from "viem";
+import fetch from "node-fetch";
+
+export class DefaultAdapter implements Adapter {
+    constructor(
+        private oracleId: string,
+        private url: string,
+    ) {
+    }
+
+    getOracleId(): string {
+        return this.oracleId;
+    }
+
+    async fetchOffchainData(
+        _client: viem.Client,
+        _oracleContract: viem.Address,
+        oracleQuery: viem.Hex,
+    ): Promise<viem.Hex> {
+        return this.fetch(oracleQuery);
+    }
+
+    private async fetch(data: viem.Hex): Promise<viem.Hex> {
+      const response = await fetch(this.url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "text/plain",
+        },
+        body: data,
+      });
+      if (response.status !== 200) {
+        throw new Error(
+          `error fetching data (${response.status}): ${await response.text()}`
+        );
+      }
+      return (await response.text()) as viem.Hex;
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
 import * as viem from "viem";
-
-import fetch from "node-fetch";
-
 import IERC7412 from "../out/IERC7412.sol/IERC7412.json";
+import { Adapter } from "./adapter";
+
+export { Adapter } from "./adapter";
+export { DefaultAdapter } from "./adapters/default";
 
 type TransactionRequest = Pick<
   viem.TransactionRequest,
@@ -10,14 +11,17 @@ type TransactionRequest = Pick<
 >;
 
 export class EIP7412 {
-  providers: Map<string, string>;
+  adapters: Map<string, Adapter>;
   multicallFunc: (txs: TransactionRequest[]) => TransactionRequest;
 
   constructor(
-    providers: Map<string, string>,
+    adapters: Adapter[],
     multicallFunc: (txs: TransactionRequest[]) => TransactionRequest
   ) {
-    this.providers = providers;
+    this.adapters = new Map();
+    adapters.forEach((adapter) => {
+        this.adapters.set(adapter.getOracleId(), adapter);
+    });
     this.multicallFunc = multicallFunc;
   }
 
@@ -38,18 +42,42 @@ export class EIP7412 {
             .data as viem.Hex, // A configurable or generalized solution is needed for finding the error data
         });
         if (err.errorName === "OracleDataRequired") {
-          const oracleRequestData = err.args![1] as viem.Hex;
-          const signedRequiredData = await this.fetchOffchainData(
-            client,
-            err.args![0] as viem.Address,
-            oracleRequestData
+          const oracleQuery = err.args![1] as viem.Hex;
+          const oracleAddress = err.args![0] as viem.Address;
+
+          const oracleId = viem.hexToString(
+            viem.trim(
+              (await client.readContract({
+                abi: IERC7412.abi,
+                address: oracleAddress,
+                functionName: "oracleId",
+                args: [],
+              })) as unknown as viem.Hex,
+              { dir: "right" }
+            )
           );
+
+          const adapter = this.adapters.get(oracleId);
+          if (adapter === undefined) {
+            throw new Error(
+              `oracle ${oracleId} not supported (supported oracles: ${Array.from(
+                this.adapters.keys()
+              ).join(",")})`
+            );
+          }
+
+          const signedRequiredData = await adapter.fetchOffchainData(
+              client,
+              oracleAddress,
+              oracleQuery
+          )
+
           multicallCalls.splice(multicallCalls.length - 1, 0, {
             to: err.args![0] as viem.Address,
             data: viem.encodeFunctionData({
               abi: IERC7412.abi,
               functionName: "fulfillOracleQuery",
-              args: [oracleRequestData, signedRequiredData],
+              args: [oracleQuery, signedRequiredData],
             }),
           });
         } else if (err.errorName === "FeeRequired") {
@@ -60,50 +88,5 @@ export class EIP7412 {
         }
       }
     }
-  }
-
-  async fetchOffchainData(
-    client: viem.PublicClient,
-    requester: viem.Address,
-    data: viem.Hex
-  ): Promise<viem.Hex> {
-    const oracleProvider = viem.hexToString(
-      viem.trim(
-        (await client.readContract({
-          abi: IERC7412.abi,
-          address: requester,
-          functionName: "oracleId",
-          args: [],
-        })) as unknown as viem.Hex,
-        { dir: "right" }
-      )
-    );
-
-    const url = this.providers.get(oracleProvider);
-
-    if (url === undefined) {
-      throw new Error(
-        `oracle provider ${oracleProvider} not supported (supported providers: ${Array.from(
-          this.providers.keys()
-        ).join(",")})`
-      );
-    }
-    return this.fetch(url, data);
-  }
-
-  async fetch(url: string, data: viem.Hex): Promise<viem.Hex> {
-    const response = await fetch(url, {
-      method: "POST",
-      headers: {
-        "Content-Type": "text/plain",
-      },
-      body: data,
-    });
-    if (response.status !== 200) {
-      throw new Error(
-        `error fetching data (${response.status}): ${await response.text()}`
-      );
-    }
-    return (await response.text()) as viem.Hex;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export class EIP7412 {
   ) {
     this.adapters = new Map();
     adapters.forEach((adapter) => {
-        this.adapters.set(adapter.getOracleId(), adapter);
+      this.adapters.set(adapter.getOracleId(), adapter);
     });
     this.multicallFunc = multicallFunc;
   }
@@ -67,10 +67,10 @@ export class EIP7412 {
           }
 
           const signedRequiredData = await adapter.fetchOffchainData(
-              client,
-              oracleAddress,
-              oracleQuery
-          )
+            client,
+            oracleAddress,
+            oracleQuery
+          );
 
           multicallCalls.splice(multicallCalls.length - 1, 0, {
             to: err.args![0] as viem.Address,

--- a/test/client.mjs
+++ b/test/client.mjs
@@ -1,14 +1,14 @@
-import eip7412 from "../dist/src/index.js";
+import eip7412, { DefaultAdapter } from "../dist/src/index.js";
 import http from "http";
 import * as viem from "viem";
 import { privateKeyToAccount } from 'viem/accounts'
 import { build, runRpc, getProvider, getFoundryArtifact, ChainDefinition } from "@usecannon/cli";
 
 async function generate7412CompatibleCall(client, multicallFunc, addressToCall, functionName) {
-	const providers = new Map(); // This may ultimately be a map of oracleIds to functions (that take configuration) for resolving oracle queries. (e.g. provide a custom gateway URL to a function with logic that parses signedOffchainData from a JSON response)
-	providers.set("TEST", "http://localhost:8000");
+    const adapters = [];
+    adapters.push(new DefaultAdapter("TEST", "http://localhost:8000"));
 
-	const converter = new eip7412.EIP7412(providers, multicallFunc);
+	const converter = new eip7412.EIP7412(adapters, multicallFunc);
 
 	return await converter.enableERC7412(client, {
 		to: addressToCall,

--- a/test/client.mjs
+++ b/test/client.mjs
@@ -1,147 +1,173 @@
 import eip7412, { DefaultAdapter } from "../dist/src/index.js";
 import http from "http";
 import * as viem from "viem";
-import { privateKeyToAccount } from 'viem/accounts'
-import { build, runRpc, getProvider, getFoundryArtifact, ChainDefinition } from "@usecannon/cli";
+import { privateKeyToAccount } from "viem/accounts";
+import {
+  build,
+  runRpc,
+  getProvider,
+  getFoundryArtifact,
+  ChainDefinition,
+} from "@usecannon/cli";
 
-async function generate7412CompatibleCall(client, multicallFunc, addressToCall, functionName) {
-    const adapters = [];
-    adapters.push(new DefaultAdapter("TEST", "http://localhost:8000"));
+async function generate7412CompatibleCall(
+  client,
+  multicallFunc,
+  addressToCall,
+  functionName
+) {
+  const adapters = [];
+  adapters.push(new DefaultAdapter("TEST", "http://localhost:8000"));
 
-	const converter = new eip7412.EIP7412(adapters, multicallFunc);
+  const converter = new eip7412.EIP7412(adapters, multicallFunc);
 
-	return await converter.enableERC7412(client, {
-		to: addressToCall,
-		data: functionName,
-	});
+  return await converter.enableERC7412(client, {
+    to: addressToCall,
+    data: functionName,
+  });
 }
 
 function startWebServer() {
-	return new Promise((resolve) => {
-		http
-			.createServer((req, res) => {
-				let body = '';
-				req.on('data', chunk => {
-					body += chunk;
-				});
+  return new Promise((resolve) => {
+    http
+      .createServer((req, res) => {
+        let body = "";
+        req.on("data", (chunk) => {
+          body += chunk;
+        });
 
-				req.on('end', () => {
-					res.writeHead(200, { "Content-Type": "text/plain" });
-					res.end(viem.encodeAbiParameters([{ type: "string" }], [`Hello World ${viem.hexToNumber(body)}`]));
-				});
-
-			})
-			.listen(8000, resolve);
-	});
+        req.on("end", () => {
+          res.writeHead(200, { "Content-Type": "text/plain" });
+          res.end(
+            viem.encodeAbiParameters(
+              [{ type: "string" }],
+              [`Hello World ${viem.hexToNumber(body)}`]
+            )
+          );
+        });
+      })
+      .listen(8000, resolve);
+  });
 }
 
 async function makeTestEnv() {
-	await startWebServer();
+  await startWebServer();
 
-	const node = await runRpc({ port: 8545 });
+  const node = await runRpc({ port: 8545 });
 
-	const info = await build({
-		provider: getProvider(node),
-		packageDefinition: { name: "erc7412test", version: "0.0.1" },
-		getArtifact: getFoundryArtifact,
-		def: new ChainDefinition({
-			name: "erc7412test",
-			version: "0.0.1",
-			contract: {
-				Multicall: {
-					artifact: "Multicall3_1", // using "multicall3.1" because it bubbles up errors
-				},
-				OffchainGreeter: {
-					artifact: "OffchainGreeter",
-				},
-			},
-		}),
-	});
+  const info = await build({
+    provider: getProvider(node),
+    packageDefinition: { name: "erc7412test", version: "0.0.1" },
+    getArtifact: getFoundryArtifact,
+    def: new ChainDefinition({
+      name: "erc7412test",
+      version: "0.0.1",
+      contract: {
+        Multicall: {
+          artifact: "Multicall3_1", // using "multicall3.1" because it bubbles up errors
+        },
+        OffchainGreeter: {
+          artifact: "OffchainGreeter",
+        },
+      },
+    }),
+  });
 
-	return info;
+  return info;
 }
 
 makeTestEnv().then((netInfo) => {
-	const senderAddr = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+  const senderAddr = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
 
-	const greeterAddress = netInfo.outputs.contracts.OffchainGreeter.address;
-	const greeterFunc = viem.encodeFunctionData({
-		abi: netInfo.outputs.contracts.OffchainGreeter.abi,
-		functionName: "greet",
-		args: [3],
-	});
+  const greeterAddress = netInfo.outputs.contracts.OffchainGreeter.address;
+  const greeterFunc = viem.encodeFunctionData({
+    abi: netInfo.outputs.contracts.OffchainGreeter.abi,
+    functionName: "greet",
+    args: [3],
+  });
 
-	function makeMulticall(calls) {
-		const ret = viem.encodeFunctionData({
-			abi: netInfo.outputs.contracts.Multicall.abi,
-			functionName: "aggregate3Value",
-			args: [
-				calls.map((call) => ({
-					target: call.to,
-					callData: call.data,
-					value: call.value || 0n,
-					allowFailure: false,
-				})),
-			],
-		});
+  function makeMulticall(calls) {
+    const ret = viem.encodeFunctionData({
+      abi: netInfo.outputs.contracts.Multicall.abi,
+      functionName: "aggregate3Value",
+      args: [
+        calls.map((call) => ({
+          target: call.to,
+          callData: call.data,
+          value: call.value || 0n,
+          allowFailure: false,
+        })),
+      ],
+    });
 
-		let totalValue = 0n;
-		for (const call of calls) {
-			totalValue += call.value || 0n;
-		}
+    let totalValue = 0n;
+    for (const call of calls) {
+      totalValue += call.value || 0n;
+    }
 
-		return {
-			account: senderAddr,
-			to: netInfo.outputs.contracts.Multicall.address,
-			data: ret,
-			value: totalValue.toString(),
-		};
-	}
+    return {
+      account: senderAddr,
+      to: netInfo.outputs.contracts.Multicall.address,
+      data: ret,
+      value: totalValue.toString(),
+    };
+  }
 
-	const walletConfig = {
-		chain: {
-			nativeCurrency: { name: "ETH", symbol: "ETH", decimals: 18 },
-			id: 13370,
-			chainName: "Cannon Localhost",
-			rpcUrls: { default: { http: ["http://localhost:8545"] } },
-			blockExplorerUrls: ["http://localhost:8000"],
-		},
-		transport: viem.custom({
-			request: async (req) => {
-				const res = await netInfo.provider.send(req.method, req.params);
-				return res;
-			},
-		}),
-	};
+  const walletConfig = {
+    chain: {
+      nativeCurrency: { name: "ETH", symbol: "ETH", decimals: 18 },
+      id: 13370,
+      chainName: "Cannon Localhost",
+      rpcUrls: { default: { http: ["http://localhost:8545"] } },
+      blockExplorerUrls: ["http://localhost:8000"],
+    },
+    transport: viem.custom({
+      request: async (req) => {
+        const res = await netInfo.provider.send(req.method, req.params);
+        return res;
+      },
+    }),
+  };
 
-	const client = viem.createPublicClient(walletConfig);
-	const walletClient = viem.createWalletClient({
-		account: privateKeyToAccount("0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"),
-		transport: walletConfig.transport,
-		chain: walletConfig.chain,
-	})
+  const client = viem.createPublicClient(walletConfig);
+  const walletClient = viem.createWalletClient({
+    account: privateKeyToAccount(
+      "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+    ),
+    transport: walletConfig.transport,
+    chain: walletConfig.chain,
+  });
 
-	generate7412CompatibleCall(client, makeMulticall, greeterAddress, greeterFunc).then((tx) => {
-		console.log("Sending multicall transaction with oracle data")
-		walletClient.sendTransaction({
-			account: senderAddr,
-			to: tx.to,
-			data: tx.data,
-			value: tx.value,
-		}).then((hash) => {
-			console.log("Multicall transaction hash: " + hash);
-			client.waitForTransactionReceipt({ hash }).then(() => {
-				console.log("Multicall transaction mined");
-				client.readContract({
-					address: greeterAddress,
-					abi: netInfo.outputs.contracts.OffchainGreeter.abi,
-					functionName: "greet",
-					args: [3],
-				}).then((res) => {
-					console.log(`Oracle data "${res}" is available on chain`)
-					process.exit(0);
-				})
-			});
-		})
-	});
+  generate7412CompatibleCall(
+    client,
+    makeMulticall,
+    greeterAddress,
+    greeterFunc
+  ).then((tx) => {
+    console.log("Sending multicall transaction with oracle data");
+    walletClient
+      .sendTransaction({
+        account: senderAddr,
+        to: tx.to,
+        data: tx.data,
+        value: tx.value,
+      })
+      .then((hash) => {
+        console.log("Multicall transaction hash: " + hash);
+        client.waitForTransactionReceipt({ hash }).then(() => {
+          console.log("Multicall transaction mined");
+          client
+            .readContract({
+              address: greeterAddress,
+              abi: netInfo.outputs.contracts.OffchainGreeter.abi,
+              functionName: "greet",
+              args: [3],
+            })
+            .then((res) => {
+              console.log(`Oracle data "${res}" is available on chain`);
+              process.exit(0);
+            });
+        });
+      });
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,19 @@
 {
-	"compilerOptions": {
-		"target": "ES2018",
-		"module": "CommonJS",
-		"moduleResolution": "node",
-		"declaration": true,
-		"declarationMap": true,
-		"sourceMap": true,
-		"strict": true,
-		"allowSyntheticDefaultImports": true,
-		"esModuleInterop": true,
-		"resolveJsonModule": true,
-		"rootDirs": ["./src"],
-		"skipLibCheck": true,
-		"outDir": "./dist"
-	},
-	"include": ["./src"],
-	"exclude": ["dist", "node_modules"]
+  "compilerOptions": {
+    "target": "ES2018",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "rootDirs": ["./src"],
+    "skipLibCheck": true,
+    "outDir": "./dist"
+  },
+  "include": ["./src"],
+  "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
This PR adds the Adapter interface that oracles can implement to provide support for ERC7412. This interface has `getOracleId` as a method to provide more flexibility for generic adapters (such as a CCIP adapter, and more). It also reuses the `fetchOffchainData` method from the code. Having the client and oracleAddress allows the adapters to be more flexible. For example, an adapter can query the fee without the revert, or support more complicated use cases that depend on the contract state.